### PR TITLE
refactor: replace sqlmodel with sqlalchemy 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ wheels/
 .pytest_cache
 
 .env*
+
+.idea/

--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,8 @@
 from typing import Annotated
 
 from fastapi import Depends
-from sqlmodel import Session, create_engine
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from app.config import log_settings, postgres_settings
 
@@ -10,10 +11,15 @@ engine = create_engine(
     echo=log_settings.db_engine_echo,
 )
 
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
 
 def get_session():
-    with Session(engine) as session:
-        yield session
-
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 DbSessionDep = Annotated[Session, Depends(get_session)]

--- a/app/database.py
+++ b/app/database.py
@@ -16,10 +16,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 def get_session():
-    db = SessionLocal()
-    try:
+    with SessionLocal() as db:
         yield db
-    finally:
-        db.close()
 
 DbSessionDep = Annotated[Session, Depends(get_session)]

--- a/app/tests/src/fixtures.py
+++ b/app/tests/src/fixtures.py
@@ -17,14 +17,13 @@ def testclient() -> TestClient:
 @pytest.fixture(scope="function", name="session")
 def session_fixture():
     """Creates and returns a database session"""
+    Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
 
-    db = SessionLocal()
-    try:
+    with SessionLocal() as db:
         yield db
-    finally:
-        db.close()
-        Base.metadata.drop_all(bind=engine)
+
+    Base.metadata.drop_all(bind=engine)
 
 @pytest.fixture(scope="function", name="testenv", autouse=True)
 def testenv_fixture(

--- a/app/tests/src/fixtures.py
+++ b/app/tests/src/fixtures.py
@@ -3,10 +3,9 @@ import os
 import pytest
 from dotenv import set_key
 from fastapi.testclient import TestClient
-from sqlmodel import Session
 
 import app.config as config
-from app.database import engine
+from app.database import Base, SessionLocal, engine
 from app.main import app
 
 
@@ -15,13 +14,17 @@ def testclient() -> TestClient:
     """Creates and returns test client"""
     return TestClient(app)
 
-
 @pytest.fixture(scope="function", name="session")
 def session_fixture():
     """Creates and returns a database session"""
-    with Session(engine) as session:
-        yield session
+    Base.metadata.create_all(bind=engine)
 
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
 
 @pytest.fixture(scope="function", name="testenv", autouse=True)
 def testenv_fixture(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pydantic-settings>=2.10.1",
     "python-dotenv>=1.1.1",
     "rapidfuzz>=3.13.0",
-    "sqlmodel>=0.0.24",
+    "sqlalchemy>=2.0.41",
     "unidecode>=1.4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "rapidfuzz" },
-    { name = "sqlmodel" },
+    { name = "sqlalchemy" },
     { name = "unidecode" },
 ]
 
@@ -54,7 +54,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
-    { name = "sqlmodel", specifier = ">=0.0.24" },
+    { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "unidecode", specifier = ">=1.4.0" },
 ]
 
@@ -719,19 +719,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/2e/677c17c5d6a004c3c45334ab1dbe7b7deb834430b282b8a0f75ae220c8eb/sqlalchemy-2.0.41-cp313-cp313-win32.whl", hash = "sha256:bfc9064f6658a3d1cadeaa0ba07570b83ce6801a1314985bf98ec9b95d74e15f", size = 2082420, upload-time = "2025-05-14T17:55:52.69Z" },
     { url = "https://files.pythonhosted.org/packages/e9/61/e8c1b9b6307c57157d328dd8b8348ddc4c47ffdf1279365a13b2b98b8049/sqlalchemy-2.0.41-cp313-cp313-win_amd64.whl", hash = "sha256:82ca366a844eb551daff9d2e6e7a9e5e76d2612c8564f58db6c19a726869c1df", size = 2108329, upload-time = "2025-05-14T17:55:54.495Z" },
     { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
-]
-
-[[package]]
-name = "sqlmodel"
-version = "0.0.24"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/4b/c2ad0496f5bdc6073d9b4cef52be9c04f2b37a5773441cc6600b1857648b/sqlmodel-0.0.24.tar.gz", hash = "sha256:cc5c7613c1a5533c9c7867e1aab2fd489a76c9e8a061984da11b4e613c182423", size = 116780, upload-time = "2025-03-07T05:43:32.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl", hash = "sha256:6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193", size = 28622, upload-time = "2025-03-07T05:43:30.37Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Migrate from SQLModel to SQLAlchemy
- Update session management to use SQLAlchemy sessionmaker pattern
- Refactor test fixtures to work with SQLAlchemy Session objects