### PR TITLE
feat(auth): add refresh token + renew endpoint + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,17 @@ wheels/
 .env*
 
 .idea/
+
+# OS / editors
+.DS_Store
+app/.DS_Store
+.vscode/
+.pycharm-venv/
+
+# uv / tools / caches
+.uv/
+.mypy_cache/
+coverage.xml
+htmlcov/
+.coverage
+*.log

--- a/app/author/models.py
+++ b/app/author/models.py
@@ -8,12 +8,12 @@ from app.person.models import Person
 
 
 class Author(Person):
-    __tablename__ = 'authors'
+    __tablename__ = "authors"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('persons.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("persons.id"), primary_key=True)
     added_by_user_id: Mapped[int | None] = mapped_column(
-        ForeignKey('users.id'), nullable=True)
+        ForeignKey("users.id"), nullable=True
+    )
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/calendar/models.py
+++ b/app/calendar/models.py
@@ -5,11 +5,12 @@ from app.database import Base
 
 
 class CalendarEntry(Base):
-    __tablename__ = 'calendar_entry'
+    __tablename__ = "calendar_entry"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     api_id: Mapped[str] = mapped_column(nullable=False, unique=True)
     title: Mapped[str | None] = mapped_column(nullable=True)
     description: Mapped[str | None] = mapped_column(nullable=True)
     recommended_song_id: Mapped[int | None] = mapped_column(
-        ForeignKey('songs.id'), nullable=True)
+        ForeignKey("songs.id"), nullable=True
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -77,6 +77,7 @@ class AuthSettings(BaseSettings):
     secret_key: str
     algorithm: str = "HS512"
     access_token_expire_minutes: int = 30
+    refresh_token_expire_days: int = 7
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/content/models.py
+++ b/app/content/models.py
@@ -8,18 +8,21 @@ from app.content_base.models import ContentBase
 
 
 class MsczContent(ContentBase):
-    __tablename__ = 'mscz_content'
+    __tablename__ = "mscz_content"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('content_base.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("content_base.id"), primary_key=True)
     c_mscz_file_id: Mapped[int] = mapped_column(
-        ForeignKey('static_content.id'), nullable=False)
+        ForeignKey("static_content.id"), nullable=False
+    )
     c_svg_file_id: Mapped[int] = mapped_column(
-        ForeignKey('static_content.id'), nullable=False)
+        ForeignKey("static_content.id"), nullable=False
+    )
     pdf_file_id: Mapped[int] = mapped_column(
-        ForeignKey('static_content.id'), nullable=False)
+        ForeignKey("static_content.id"), nullable=False
+    )
     mp3_file_id: Mapped[int | None] = mapped_column(
-        ForeignKey('static_content.id'), nullable=True)
+        ForeignKey("static_content.id"), nullable=True
+    )
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/content_base/models.py
+++ b/app/content_base/models.py
@@ -6,7 +6,7 @@ from app.database import Base
 
 
 class ContentBase(Base):
-    __tablename__ = 'content_base'
+    __tablename__ = "content_base"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     type: Mapped[str]

--- a/app/database.py
+++ b/app/database.py
@@ -15,8 +15,10 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
 
+
 def get_session():
     with SessionLocal() as db:
         yield db
+
 
 DbSessionDep = Annotated[Session, Depends(get_session)]

--- a/app/person/models.py
+++ b/app/person/models.py
@@ -7,14 +7,15 @@ from app.database import Base
 
 
 class Person(Base):
-    __tablename__ = 'persons'
+    __tablename__ = "persons"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(nullable=False)
     surname: Mapped[str] = mapped_column(nullable=False)
     description: Mapped[str | None] = mapped_column(nullable=True)
     avatar: Mapped[int | None] = mapped_column(
-        ForeignKey('static_content.id'), nullable=True)
+        ForeignKey("static_content.id"), nullable=True
+    )
 
     __mapper_args__: ClassVar = {
         "polymorphic_identity": "persons",

--- a/app/review/models.py
+++ b/app/review/models.py
@@ -7,11 +7,10 @@ from app.database import Base
 
 
 class ReviewComment(Base):
-    __tablename__ = 'review_comments'
+    __tablename__ = "review_comments"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    commenter_id: Mapped[int] = mapped_column(
-        ForeignKey('users.id'), nullable=False)
+    commenter_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     content: Mapped[str] = mapped_column(nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/app/song/models.py
+++ b/app/song/models.py
@@ -9,30 +9,36 @@ from app.database import Base
 
 
 class Song(ContentBase):
-    __tablename__ = 'songs'
+    __tablename__ = "songs"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('content_base.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("content_base.id"), primary_key=True)
     title: Mapped[str] = mapped_column(nullable=False)
-    author: Mapped[int] = mapped_column(
-        ForeignKey('persons.id'), nullable=False)
+    author: Mapped[int] = mapped_column(ForeignKey("persons.id"), nullable=False)
     description: Mapped[str] = mapped_column(nullable=True)
     added_by_user_id: Mapped[int | None] = mapped_column(
-        ForeignKey('users.id'), nullable=True)
+        ForeignKey("users.id"), nullable=True
+    )
     search_tag_id: Mapped[int | None] = mapped_column(
-        ForeignKey('tags.id'), nullable=True)
+        ForeignKey("tags.id"), nullable=True
+    )
     song_part_id: Mapped[int | None] = mapped_column(
-        ForeignKey('song_parts.id'), nullable=True)
+        ForeignKey("song_parts.id"), nullable=True
+    )
     song_order_id: Mapped[int | None] = mapped_column(
-        ForeignKey('song_order.id'), nullable=True)
+        ForeignKey("song_order.id"), nullable=True
+    )
     mscz_id: Mapped[int | None] = mapped_column(
-        ForeignKey('mscz_content.id'), nullable=True)
+        ForeignKey("mscz_content.id"), nullable=True
+    )
     user_content_id: Mapped[int | None] = mapped_column(
-        ForeignKey('user_content.id'), nullable=True)
+        ForeignKey("user_content.id"), nullable=True
+    )
     related_id: Mapped[int | None] = mapped_column(
-        ForeignKey('songs.id'), nullable=True)
+        ForeignKey("songs.id"), nullable=True
+    )
     lang_tag_id: Mapped[int | None] = mapped_column(
-        ForeignKey('tags.id'), nullable=True)
+        ForeignKey("tags.id"), nullable=True
+    )
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -51,26 +57,25 @@ class Song(ContentBase):
 
 
 class SongOrder(Base):
-    __tablename__ = 'song_order'
+    __tablename__ = "song_order"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order: Mapped[int] = mapped_column(nullable=False)
-    part_id: Mapped[int] = mapped_column(
-        ForeignKey('song_parts.id'), nullable=False)
+    part_id: Mapped[int] = mapped_column(ForeignKey("song_parts.id"), nullable=False)
 
 
 class SongPart(Base):
-    __tablename__ = 'song_parts'
+    __tablename__ = "song_parts"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    tag_id: Mapped[int] = mapped_column(
-        ForeignKey('tags.id'), nullable=False)
+    tag_id: Mapped[int] = mapped_column(ForeignKey("tags.id"), nullable=False)
     verses_id: Mapped[int | None] = mapped_column(
-        ForeignKey('song_verses.id'), nullable=True)
+        ForeignKey("song_verses.id"), nullable=True
+    )
 
 
 class SongVerse(Base):
-    __tablename__ = 'song_verses'
+    __tablename__ = "song_verses"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order: Mapped[int] = mapped_column(nullable=False)
@@ -78,17 +83,17 @@ class SongVerse(Base):
 
 
 class SongMr(Base):
-    __tablename__ = 'song_mr'
+    __tablename__ = "song_mr"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     reviewable_id: Mapped[int] = mapped_column(
-        ForeignKey('content_base.id'), nullable=False)
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey('users.id'), nullable=False)
-    redactor_id: Mapped[int] = mapped_column(
-        ForeignKey('users.id'), nullable=False)
+        ForeignKey("content_base.id"), nullable=False
+    )
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    redactor_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     comments: Mapped[int | None] = mapped_column(
-        ForeignKey('review_comments.id'), nullable=True)
+        ForeignKey("review_comments.id"), nullable=True
+    )
     closed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=True,

--- a/app/static_content/models.py
+++ b/app/static_content/models.py
@@ -7,10 +7,9 @@ from app.content_base.models import ContentBase
 
 
 class StaticContent(ContentBase):
-    __tablename__ = 'static_content'
+    __tablename__ = "static_content"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('content_base.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("content_base.id"), primary_key=True)
     path: Mapped[str] = mapped_column(unique=True, nullable=False)
 
     __mapper_args__: ClassVar = {

--- a/app/tests/calendar/test_calendar_models.py
+++ b/app/tests/calendar/test_calendar_models.py
@@ -16,7 +16,8 @@ def test_create_calendar_entry(session):
     session.flush()
     session.commit()
 
-    entry = CalendarEntry(api_id="abc123",
+    entry = CalendarEntry(
+        api_id="abc123",
         title="Meeting",
         description="Daily sync",
         recommended_song_id=song.id,
@@ -92,7 +93,8 @@ def test_get_calendar_entry(session):
     session.add(song)
     session.commit()
 
-    entry = CalendarEntry(api_id="read123",
+    entry = CalendarEntry(
+        api_id="read123",
         title="Read Event",
         recommended_song_id=song.id,
     )

--- a/app/tests/content_base/test_content_base_models.py
+++ b/app/tests/content_base/test_content_base_models.py
@@ -29,6 +29,7 @@ def test_delete_content_base(session):
     session.delete(content_base)
     session.commit()
 
-    deleted_content_base = session.query(
-        ContentBase).filter_by(id=content_base.id).first()
+    deleted_content_base = (
+        session.query(ContentBase).filter_by(id=content_base.id).first()
+    )
     assert deleted_content_base is None

--- a/app/tests/static_content/test_static_content_models.py
+++ b/app/tests/static_content/test_static_content_models.py
@@ -25,8 +25,9 @@ def test_get_static_content(session):
     session.add(static_content)
     session.commit()
 
-    retrieved_content = session.query(StaticContent).filter_by(
-        path="/images/avatar.jpg").first()
+    retrieved_content = (
+        session.query(StaticContent).filter_by(path="/images/avatar.jpg").first()
+    )
     assert retrieved_content is not None
     assert retrieved_content.path == "/images/avatar.jpg"
     assert isinstance(retrieved_content.id, int)
@@ -40,8 +41,9 @@ def test_update_static_content(session):
     static_content.path = "/images/new_avatar.jpg"
     session.commit()
 
-    updated_content = session.query(StaticContent).filter_by(
-        id=static_content.id).first()
+    updated_content = (
+        session.query(StaticContent).filter_by(id=static_content.id).first()
+    )
     assert updated_content.path == "/images/new_avatar.jpg"
 
 
@@ -53,8 +55,9 @@ def test_delete_static_content(session):
     session.delete(static_content)
     session.commit()
 
-    deleted_content = session.query(StaticContent).filter_by(
-        id=static_content.id).first()
+    deleted_content = (
+        session.query(StaticContent).filter_by(id=static_content.id).first()
+    )
     assert deleted_content is None
 
 

--- a/app/tests/user/test_user_router.py
+++ b/app/tests/user/test_user_router.py
@@ -39,6 +39,11 @@ def _auth_header(token: str):
     return {"Authorization": f"Bearer {token}"}
 
 
+def _renew(client, refresh_token: str):
+    # Refresh token in JSON (snake_case)
+    return client.post("/user/renew", json={"refresh_token": refresh_token})
+
+
 def test_user_me_requires_auth(testclient):
     resp = testclient.get("/user")
     assert resp.status_code == 401  # unauthorized when no token
@@ -49,7 +54,10 @@ def test_user_register_returns_token_and_me_works_with_token(testclient):
     r = _register_user(testclient)
     assert r.status_code == 200, f"{r.text}"
     data = r.json()
+    # access + bearer type
     assert "accessToken" in data and data.get("tokenType") == "bearer"
+    # refreshToken
+    assert "refreshToken" in data, "refreshToken nie je v odpovedi /user/register"
 
     # Call /me with token
     me = testclient.get("/user", headers=_auth_header(data["accessToken"]))
@@ -67,7 +75,10 @@ def test_user_login_success_after_register(testclient):
     r = _login(testclient, "bob@example.com", "Pw_123456")
     assert r.status_code == 200
     j = r.json()
+    # access + bearer type
     assert "accessToken" in j and j.get("tokenType") == "bearer"
+    # refreshToken from login
+    assert "refreshToken" in j
 
 
 def test_user_login_wrong_password(testclient):
@@ -99,3 +110,25 @@ def test_user_register_invalid_password_rejected(testclient):
     assert r.status_code == 422, (
         f"Expected 422 for invalid password, got {r.status_code}: {r.text}"
     )
+
+
+# Test /user/renew (refresh -> new access)
+def test_user_renew_issues_new_access_token_and_me_works(testclient):
+    # 1) Register and take refresh token
+    r = _register_user(testclient, email="renew@example.com", password="Pw_Renew1!")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert "refreshToken" in data, "refreshToken chýba v odpovedi /user/register"
+    refresh = data["refreshToken"]
+
+    # 2) Send refresh token to /user/renew → expect new access token
+    r2 = _renew(testclient, refresh)
+    assert r2.status_code == 200, r2.text
+    renew_data = r2.json()
+    assert "accessToken" in renew_data and renew_data.get("tokenType") == "bearer"
+
+    new_access = renew_data["accessToken"]
+
+    # 3) New access token valid for /user
+    me = testclient.get("/user", headers=_auth_header(new_access))
+    assert me.status_code == 200, me.text

--- a/app/tests/user_role/test_user_role_models.py
+++ b/app/tests/user_role/test_user_role_models.py
@@ -48,6 +48,7 @@ def test_delete_user_role(session):
     deleted_user_role = session.query(UserRole).filter_by(id=user_role.id).first()
     assert deleted_user_role is None
 
+
 def test_user_role_unique_constraint(session):
     user_role1 = UserRole(role="Admin")
     user_role2 = UserRole(role="Admin")

--- a/app/user/auth.py
+++ b/app/user/auth.py
@@ -9,7 +9,7 @@ from app.config import auth_settings
 
 pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/user/login")
 
 
 def verify_password(plain_password: SecretStr, hashed_password: SecretStr) -> bool:
@@ -31,10 +31,25 @@ def create_access_token(
 ):
     to_encode = data.copy()
     expire = datetime.now(UTC) + expires_delta
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(
+    to_encode.update({"exp": expire, "type": "access"})
+    return jwt.encode(
         to_encode,
         auth_settings.secret_key,
         algorithm=auth_settings.algorithm,
     )
-    return encoded_jwt
+
+
+def create_refresh_token(
+    data: dict,
+    expires_delta: timedelta = timedelta(
+        days=auth_settings.refresh_token_expire_days,
+    ),
+):
+    to_encode = data.copy()
+    expire = datetime.now(UTC) + expires_delta
+    to_encode.update({"exp": expire, "type": "refresh"})  # ⬅️ dôležité odlíšenie
+    return jwt.encode(
+        to_encode,
+        auth_settings.secret_key,
+        algorithm=auth_settings.algorithm,
+    )

--- a/app/user/models.py
+++ b/app/user/models.py
@@ -12,15 +12,13 @@ if TYPE_CHECKING:
 
 
 class User(Person):
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('persons.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("persons.id"), primary_key=True)
     email: Mapped[str] = mapped_column(nullable=False, unique=True)
     hashed_password: Mapped[str] = mapped_column(nullable=False)
     mobile: Mapped[str] = mapped_column(nullable=True, unique=True)
-    role_id: Mapped[int] = mapped_column(
-        ForeignKey('user_roles.id'), nullable=False)
+    role_id: Mapped[int] = mapped_column(ForeignKey("user_roles.id"), nullable=False)
     registered_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -32,21 +30,22 @@ class User(Person):
 
 
 class UserContent(ContentBase):
-    __tablename__ = 'user_content'
+    __tablename__ = "user_content"
 
-    id: Mapped[int] = mapped_column(
-        ForeignKey('content_base.id'), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("content_base.id"), primary_key=True)
     title: Mapped[str] = mapped_column(nullable=False)
     description: Mapped[str] = mapped_column(nullable=True)
     file_id: Mapped[int | None] = mapped_column(
-        ForeignKey('static_content.id'), nullable=True)
+        ForeignKey("static_content.id"), nullable=True
+    )
     mscz_id: Mapped[int | None] = mapped_column(
-        ForeignKey('mscz_content.id'), nullable=True)
+        ForeignKey("mscz_content.id"), nullable=True
+    )
     author: Mapped[str] = mapped_column(nullable=True)
     added_by_user_id: Mapped[int] = mapped_column(
-        ForeignKey('users.id'), nullable=False)
-    tag_id: Mapped[int | None] = mapped_column(
-        ForeignKey('tags.id'), nullable=True)
+        ForeignKey("users.id"), nullable=False
+    )
+    tag_id: Mapped[int | None] = mapped_column(ForeignKey("tags.id"), nullable=True)
     added_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/user/router.py
+++ b/app/user/router.py
@@ -1,15 +1,25 @@
 from datetime import timedelta
 from typing import Annotated
 
+import jwt
 from fastapi import APIRouter, Depends
 from fastapi.security import OAuth2PasswordRequestForm
+from jwt import InvalidTokenError
 from pydantic.types import SecretStr
 
 from app.config import auth_settings
 from app.database import DbSessionDep
-from app.user.auth import create_access_token
-from app.user.schema import Token, UserCreate, UserInDb, UserRead
-from app.user.service import authenticate_user, create_user, get_current_user
+from app.user.auth import create_access_token, create_refresh_token
+from app.user.exceptions import InvalidCredentialsException
+from app.user.schema import (
+    RefreshRequest,
+    Token,
+    TokenWithRefresh,
+    UserCreate,
+    UserInDb,
+    UserRead,
+)
+from app.user.service import authenticate_user, create_user, get_current_user, get_user
 
 user_router = APIRouter(
     prefix="/user",
@@ -29,22 +39,32 @@ async def me(
 async def login(
     session: DbSessionDep,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
-) -> Token:
+) -> TokenWithRefresh:
     secret_password = SecretStr(form_data.password)
     user = authenticate_user(session, form_data.username, secret_password)
     access_token_expires = timedelta(minutes=auth_settings.access_token_expire_minutes)
+
     access_token = create_access_token(
         data={"sub": user.email},
         expires_delta=access_token_expires,
     )
-    return Token(access_token=access_token, token_type="bearer")
+
+    refresh_token = create_refresh_token(
+        data={"sub": user.email},
+    )
+
+    return TokenWithRefresh(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+    )
 
 
 @user_router.post("/register")
 async def register(
     session: DbSessionDep,
     new_user: UserCreate,
-) -> Token:
+) -> TokenWithRefresh:
     user = create_user(
         session=session,
         email=new_user.email,
@@ -59,7 +79,46 @@ async def register(
         data={"sub": user.email},
         expires_delta=access_token_expires,
     )
-    return Token(access_token=access_token, token_type="bearer")
+    refresh_token = create_refresh_token(
+        data={"sub": user.email},
+    )
+
+    return TokenWithRefresh(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+    )
+
+
+@user_router.post("/renew")
+async def renew_token(
+    body: RefreshRequest,
+    session: DbSessionDep,
+) -> Token:
+    try:
+        payload = jwt.decode(
+            body.refresh_token,
+            auth_settings.secret_key,
+            algorithms=[auth_settings.algorithm],
+        )
+        # token type check
+        if payload.get("type") != "refresh":
+            raise InvalidCredentialsException("Wrong token type")
+
+        sub = payload.get("sub")
+        if not sub:
+            raise InvalidCredentialsException("Invalid token")
+
+    except InvalidTokenError as e:
+        raise InvalidCredentialsException("Invalid refresh token") from e
+
+    # user check
+    user = get_user(session, sub)
+    if user is None:
+        raise InvalidCredentialsException("User not found")
+
+    new_access_token = create_access_token(data={"sub": sub})
+    return Token(access_token=new_access_token, token_type="bearer")
 
 
 # / token -> User

--- a/app/user/schema.py
+++ b/app/user/schema.py
@@ -79,6 +79,28 @@ class Token(BaseModel):
     )
 
 
+class TokenWithRefresh(Token):
+    refresh_token: str
+
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(
+            validation_alias=to_snake,
+            serialization_alias=to_camel,
+        ),
+    )
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+    model_config = ConfigDict(
+        alias_generator=AliasGenerator(
+            validation_alias=to_snake,
+            serialization_alias=to_camel,
+        ),
+    )
+
+
 class UserBase(BaseModel):
     email: EmailStr
     mobile: PhoneNumber | None = Field(default=None)

--- a/app/user/service.py
+++ b/app/user/service.py
@@ -22,7 +22,7 @@ from app.user.models import User
 from app.user.schema import UserInDb
 from app.user_role.models import UserRole
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/user/login")
 
 
 def get_user(session: Session, email: str) -> UserInDb | None:


### PR DESCRIPTION
## Summary
This PR adds a refresh-token flow to the authentication module:
- Issues a `refreshToken` together with `accessToken` on **/user/login** and **/user/register**.
- Adds **POST /user/renew** to exchange a valid `refreshToken` for a new short-lived `accessToken`.
- Updates tests to cover the new flow.

## Why
Short-lived access tokens improve security. The refresh token enables seamless UX (silent refresh) without asking users to re-login frequently.

## What changed
- **Schemas**: Introduced `TokenWithRefresh` (includes `accessToken`, `tokenType`, `refreshToken`).  
- **Auth**: 
  - `/user/login` and `/user/register` now return `TokenWithRefresh`.
  - `/user/renew` accepts JSON body `{ "refresh_token": "<JWT>" }` and returns a new `accessToken`.
  - Password hashing remains Argon2; JWT uses the configured `AUTH_SECRET_KEY` and algorithm from settings.  
- **Routing/Service**: Decode/validate refresh token (`sub` claimed email) and issue a fresh access token.
- **Tests**: Extended `test_user_router.py` to:
  - assert `refreshToken` is returned on login/register,
  - call `/user/renew` and use the renewed `accessToken` for `/user`.

## How to test (manual)
1) Register → receive both tokens
   - `POST /user/register` (JSON body with email/password/name/...)
   - Response contains `accessToken`, `refreshToken`, `tokenType: "bearer"`.
2) Access a protected route:
   - `GET /user` with header `Authorization: Bearer <accessToken>` → 200
3) Renew:
   - `POST /user/renew` with body `{ "refresh_token": "<refreshToken>" }`
   - Response contains a new `accessToken`.
4) Use the new `accessToken` on `GET /user` → 200

## How to test (automated)
- `uv run ruff check` → ✅
- `uv run pyright app/` → ✅
- `uv run pytest` → ✅ (all tests pass)

## Security notes
- Access tokens are short-lived; refresh tokens have a longer lifetime.
- Current implementation returns refresh token in the JSON body. (A future hardening step could store it in an HttpOnly, Secure cookie to mitigate XSS.)

## Breaking changes
- Login/Register responses now include `refreshToken`. If any client strictly validates the exact shape of the previous response, it may need to accept the new field.
- No database migrations.

## Misc
- No changes to existing DB schema.
- Imports & formatting aligned with Ruff; types pass Pyright.
